### PR TITLE
Fix for issue with windows & aiodns

### DIFF
--- a/nexfil.py
+++ b/nexfil.py
@@ -74,6 +74,10 @@ from json import loads
 from datetime import datetime
 from requests import get, exceptions
 from os import getenv, path, makedirs
+from sys import platform
+
+if platform == 'win32':
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 gh_version = ''
 twitter_url = ''


### PR DESCRIPTION
Fix for the following issue Cf https://github.com/saghul/aiodns/issues/78
```
Exception ignored from cffi callback <function _sock_state_cb at 0x000001B7B81FDC10>:
Traceback (most recent call last):
  File "[...]\LocalCache\local-packages\Python38\site-packages\pycares\__init__.py", line 99, in _sock_state_cb
    sock_state_cb(socket_fd, readable, writable)
  File "[...]\LocalCache\local-packages\Python38\site-packages\aiodns\__init__.py", line 111, in _sock_state_cb
    self.loop.add_reader(fd, self._handle_event, fd, READ)
  File "PYTHONPATH\lib\asyncio\events.py", line 501, in add_reader
    raise NotImplementedError
NotImplementedError:
```